### PR TITLE
leaderboard styling

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -444,11 +444,13 @@
     border-bottom: 1px solid #eaeaea;
     white-space: nowrap;
     overflow-y: hidden;
+    cursor: pointer;
   }
 
   .modalBody {
     max-height: .001vh;
     transition: max-height 0.4s;
+    overflow: hidden;
   }
 
   .modalBody.open {

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -450,7 +450,7 @@
   .modalBody {
     max-height: .001vh;
     transition: max-height 0.4s;
-    overflow: hidden;
+    overflow: auto;
   }
 
   .modalBody.open {


### PR DESCRIPTION
- Pointer cursor on hover the header
- `modalBody` no longer overflows on collapsing